### PR TITLE
Fix XML renderer crash

### DIFF
--- a/geshi/classes/class.geshistyler.php
+++ b/geshi/classes/class.geshistyler.php
@@ -109,6 +109,17 @@ class GeSHiStyler
     /**#@-*/
 
     // }}}
+    // {{{ getLanguage()
+
+    /**
+     * Retrieves the language this styler is using.
+     */
+    function getLanguage ()
+    {
+        return $this->language;
+    }
+
+    // }}}
     // {{{ setLanguage()
 
     /**
@@ -305,6 +316,17 @@ class GeSHiStyler
     function setRenderer (GeSHiRenderer $renderer)
     {
         $this->_renderer = $renderer;
+    }
+
+    // }}}
+    // {{{ getThemes()
+
+    /**
+     * Retrieves an array with the themes of this styler.
+     */
+    function getThemes ()
+    {
+        return $this->themes;
     }
 
     // }}}

--- a/geshi/classes/renderers/class.geshirendererxml.php
+++ b/geshi/classes/renderers/class.geshirendererxml.php
@@ -123,10 +123,11 @@ class GeSHiRendererXML extends GeSHiRenderer
     function getHeader ()
     {
 	    // TODO: Add doctype (if needed)
+        $themes = $this->_styler->getThemes();
         return '<?xml version="1.0"?>' . "\n" .
 		'<!DOCTYPE GESHI SYSTEM "HERE_GOES_URL_TO_DTD">' . "\n" .
 		"\n" .
-		'<geshi language="' . $this->_styler->language . '" theme="' . $this->_styler->themes[0] . '">' . "\n";
+		'<geshi language="' . $this->_styler->getLanguage() . '" theme="' . $themes[0] . '">' . "\n";
     }
 
     // }}}


### PR DESCRIPTION
The XML renderer crashed because two styler properties it expected to be public are now private. Fixed by adding the corresponding getXXX functions to the styler.
