### PR TITLE
Fix styles specified as arrays instead of as CSS strings

### DIFF
--- a/geshi/classes/class.geshistyler.php
+++ b/geshi/classes/class.geshistyler.php
@@ -506,7 +506,7 @@ class GeSHiStyler
             );
 
         if(is_array($style)) {
-            return GeSHiStyler::array_merge_recursive_unique($style, $result);
+            return array_replace_recursive($result, $style);
         }
 
         //No array, so we have to parse CSS ...
@@ -536,54 +536,6 @@ class GeSHiStyler
     }
 
     // }}}
-
-    private static function array_merge_recursive_unique()
-    {
-        $arrays = func_get_args();
-        $remains = $arrays;
-
-        // We walk through each arrays and put value in the results (without
-        // considering previous value).
-        $result = array();
-
-        // loop available array
-        foreach($arrays as $array) {
-
-            // The first remaining array is $array. We are processing it. So
-            // we remove it from remaing arrays.
-            array_shift($remains);
-
-            // We don't care non array param, like array_merge since PHP 5.0.
-            if(is_array($array)) {
-                // Loop values
-                foreach($array as $key => $value) {
-                    if(is_array($value)) {
-                        // we gather all remaining arrays that have such key available
-                        $args = array();
-                        foreach($remains as $remain) {
-                            if(array_key_exists($key, $remain)) {
-                                array_push($args, $remain[$key]);
-                            }
-                        }
-
-                        if(count($args) > 2) {
-                            // put the recursion
-                            $result[$key] = call_user_func_array(array(__CLASS__, __FUNCTION__), $args);
-                        } else {
-                            foreach($value as $vkey => $vval) {
-                                $result[$key][$vkey] = $vval;
-                            }
-                        }
-                    } else {
-                        // simply put the value
-                        $result[$key] = $value;
-                    }
-                }
-            }
-        }
-
-        return $result;
-    }
 
     /**
      * GeSHiStyler::_parseColor()


### PR DESCRIPTION
The function array_merge_recursive_unique() seems broken, as it did not produce the expected result. Replace it by the native function array_replace_recursive (requires PHP 5.3.0).
