### PR TITLE
Add background and alpha support to the CSS parser

### DIFF
--- a/geshi/classes/class.geshistyler.php
+++ b/geshi/classes/class.geshistyler.php
@@ -628,7 +628,7 @@ class GeSHiStyler
 
                 );
 
-            if(isset($htmlColors[$color])) {
+            if(array_key_exists($color, $htmlColors)) {
                 return $htmlColors[$color];
             }
 

--- a/geshi/classes/class.geshistyler.php
+++ b/geshi/classes/class.geshistyler.php
@@ -477,7 +477,7 @@ class GeSHiStyler
                     "R" => 0.0,         //Red channel
                     "G" => 0.0,         //Green channel
                     "B" => 0.0,         //Blue channel
-                    "A" => 0.0          //Transparency (optional)
+                    "A" => 1.0          //Transparency (optional)
                     ),
                 "style" => array(
                     "bold" => false,    //Bold font

--- a/geshi/classes/class.geshistyler.php
+++ b/geshi/classes/class.geshistyler.php
@@ -516,7 +516,11 @@ class GeSHiStyler
             //We got a text color, let's analyze it:
             $color = GeSHiStyler::_parseColor($match[1]);
             if ($color) {
-                $result['font']['color'] = array_replace($result['font']['color'], $color);
+                if ($result['font']['color']) {
+                    $result['font']['color'] = array_replace($result['font']['color'], $color);
+                } else {
+                    $result['font']['color'] = $color;
+                }
             }
         }
 
@@ -524,7 +528,11 @@ class GeSHiStyler
             //We got a background color, let's analyze it:
             $color = GeSHiStyler::_parseColor($match[1]);
             if ($color) {
-                $result['back']['color'] = array_replace($result['back']['color'], $color);
+                if ($result['back']['color']) {
+                    $result['back']['color'] = array_replace($result['back']['color'], $color);
+                } else {
+                    $result['back']['color'] = $color;
+                }
             }
         }
 

--- a/geshi/classes/class.geshistyler.php
+++ b/geshi/classes/class.geshistyler.php
@@ -514,12 +514,18 @@ class GeSHiStyler
         //First of the color:
         if(preg_match('/\b(?<!-)color\s*:\s*(#(?i:[\da-f]{3}(?:[\da-f]{3})?)|\w+)/', $style, $match)) {
             //We got a text color, let's analyze it:
-            $result['font']['color'] = GeSHiStyler::_parseColor($match[1]);
+            $color = GeSHiStyler::_parseColor($match[1]);
+            if ($color) {
+                $result['font']['color'] = array_replace($result['font']['color'], $color);
+            }
         }
 
         if(preg_match('/\b(?<!-)background(?:-color)?\s*:\s*(#(?i:[\da-f]{3}(?:[\da-f]{3})?)|\w+)/', $style, $match)) {
             //We got a background color, let's analyze it:
-            $result['back']['color'] = GeSHiStyler::_parseColor($match[1]);
+            $color = GeSHiStyler::_parseColor($match[1]);
+            if ($color) {
+                $result['back']['color'] = array_replace($result['back']['color'], $color);
+            }
         }
 
         if(preg_match('/\b(?<!-)font-style\s*:\s*(\w+)/', $style, $match)) {
@@ -591,43 +597,45 @@ class GeSHiStyler
     }
 
     /**
-     * GeSHiStyler::_parseColor()
+     * Parses the input string as a CSS color, returning an array in the
+     * internal RGBA format, possibly partial (in which case the missing
+     * elements will be filled with default values), or false in case of
+     * parse error.
      *
      * @param string $color
-     * @return
+     * @return array|false
      */
     private static function _parseColor($color)
     {
-        $result = array("R" => 0.0, "G" => 0.0, "B" => 0.0, "A" => 0.0);
-
         if('' == $color) {
-            return $result;
+            return false;
         }
 
         if('#' != $color[0]) {
             static $htmlColors = array(
-                "black" =>      array("R"=>0.0, "G"=>0.0, "B"=>0.0, "A"=>0.0),
-                "white" =>      array("R"=>1.0, "G"=>1.0, "B"=>1.0, "A"=>0.0),
+                "black" =>      array("R"=>0.0, "G"=>0.0, "B"=>0.0),
+                "white" =>      array("R"=>1.0, "G"=>1.0, "B"=>1.0),
 
-                "red" =>        array("R"=>1.0, "G"=>0.0, "B"=>0.0, "A"=>0.0),
-                "yellow" =>     array("R"=>1.0, "G"=>1.0, "B"=>0.0, "A"=>0.0),
-                "lime" =>       array("R"=>0.0, "G"=>1.0, "B"=>0.0, "A"=>0.0),
-                "cyan" =>       array("R"=>0.0, "G"=>1.0, "B"=>1.0, "A"=>0.0),
-                "blue" =>       array("R"=>0.0, "G"=>0.0, "B"=>1.0, "A"=>0.0),
-                "magenta" =>    array("R"=>1.0, "G"=>0.0, "B"=>1.0, "A"=>0.0),
+                "red" =>        array("R"=>1.0, "G"=>0.0, "B"=>0.0),
+                "yellow" =>     array("R"=>1.0, "G"=>1.0, "B"=>0.0),
+                "lime" =>       array("R"=>0.0, "G"=>1.0, "B"=>0.0),
+                "cyan" =>       array("R"=>0.0, "G"=>1.0, "B"=>1.0),
+                "blue" =>       array("R"=>0.0, "G"=>0.0, "B"=>1.0),
+                "magenta" =>    array("R"=>1.0, "G"=>0.0, "B"=>1.0),
 
-                "darkgrey" =>   array("R"=>0.4, "G"=>0.4, "B"=>0.4, "A"=>0.0),
-                "lightgrey" =>  array("R"=>0.8, "G"=>0.8, "B"=>0.8, "A"=>0.0),
+                "darkgrey" =>   array("R"=>0.4, "G"=>0.4, "B"=>0.4),
+                "lightgrey" =>  array("R"=>0.8, "G"=>0.8, "B"=>0.8),
 
                 );
 
             if(isset($htmlColors[$color])) {
                 return $htmlColors[$color];
-            } else {
-                return $result;
             }
+
+            return false;
         }
 
+        $result = array();
         if(4 == strlen($color)) {
             $result['R'] = intval($color[1], 16) / 15.0;
             $result['G'] = intval($color[2], 16) / 15.0;

--- a/geshi/classes/class.geshistyler.php
+++ b/geshi/classes/class.geshistyler.php
@@ -517,6 +517,11 @@ class GeSHiStyler
             $result['font']['color'] = GeSHiStyler::_parseColor($match[1]);
         }
 
+        if(preg_match('/\b(?<!-)background(?:-color)?\s*:\s*(#(?i:[\da-f]{3}(?:[\da-f]{3})?)|\w+)/', $style, $match)) {
+            //We got a background color, let's analyze it:
+            $result['back']['color'] = GeSHiStyler::_parseColor($match[1]);
+        }
+
         if(preg_match('/\b(?<!-)font-style\s*:\s*(\w+)/', $style, $match)) {
             //We got an italics setting
             $result['font']['style']['italic'] = 'italic' == strtolower($match[1]);

--- a/geshi/classes/class.geshistyler.php
+++ b/geshi/classes/class.geshistyler.php
@@ -650,8 +650,9 @@ class GeSHiStyler
                 $colors = explode(',', substr($color, 4 + $has_alpha, -1));
 
                 // Validate arg count
-                if (count($colors) != 3 + $has_alpha)
+                if (count($colors) != 3 + $has_alpha) {
                     return false;
+                }
 
                 $idx_to_color = array("R", "G", "B", "A");
 


### PR DESCRIPTION
Support `background: <color>` and `background-color: <color>`. The `<color>` can now be `rgb(r, g, b)` or `rgba(r, g, b, a)`, as percentage or as a number from 0 to 255, according to the CSS3 specifications http://www.w3.org/TR/css3-color/#rgba-color and following the CSS2 grammar rules in http://www.w3.org/TR/CSS2/grammar.html

Changes the semantics of `_parseColor` so that it can return an array partially filled, to allow the missing elements to be filled from defaults (e.g. if there's no alpha specified, it's not returned) and not from its own default. Additionally, now it returns `false` to indicate parse failure. Currently, the only caller (`_parseCSS`) deals with a parse error by using the default color, so it's equivalent to returning an empty array, but the new semantics would allow for example to issue a warning, should that mechanism exist.
